### PR TITLE
Use composer API instead of checking explicit paths

### DIFF
--- a/src/Extender.php
+++ b/src/Extender.php
@@ -78,7 +78,7 @@ class Extender implements PluginInterface, EventSubscriberInterface
             $directory = $installationManager->getInstallPath($consolePackage);
           }
         }
-        if(empty($outputPath)) {
+        if(empty($directory)) {
           // cwd should be the project root.  This is the same logic Symfony uses.
           $directory = getcwd();
         }

--- a/src/Extender.php
+++ b/src/Extender.php
@@ -64,21 +64,21 @@ class Extender implements PluginInterface, EventSubscriberInterface
         $repositoryManager = $composer->getRepositoryManager();
         $localRepository = $repositoryManager->getLocalRepository();
 
-        foreach($localRepository->getPackages() as $package) {
-          if($installationManager->isPackageInstalled($localRepository, $package)) {
-            if($package->getType() === 'drupal-console-library') {
+        foreach ($localRepository->getPackages() as $package) {
+          if ($installationManager->isPackageInstalled($localRepository, $package)) {
+            if ($package->getType() === 'drupal-console-library') {
               $extenderManager->addConfigFile($installationManager->getInstallPath($package) . '/console.services.yml');
               $extenderManager->addConfigFile($installationManager->getInstallPath($package) . '/console.config.yml');
             }
           }
         }
 
-        if($consolePackage = $localRepository->findPackage('drupal/console', '*')) {
-          if($localRepository->hasPackage($consolePackage)) {
+        if ($consolePackage = $localRepository->findPackage('drupal/console', '*')) {
+          if ($localRepository->hasPackage($consolePackage)) {
             $directory = $installationManager->getInstallPath($consolePackage);
           }
         }
-        if(empty($directory)) {
+        if (empty($directory)) {
           // cwd should be the project root.  This is the same logic Symfony uses.
           $directory = getcwd();
         }

--- a/src/Extender.php
+++ b/src/Extender.php
@@ -52,6 +52,9 @@ class Extender implements PluginInterface, EventSubscriberInterface
      */
     public function processPackages(PackageEvent $event)
     {
+        // Explicit require, because during uninstallation, this class can't be
+        // autoloaded.
+        require_once './ExtenderManager.php';
         $extenderManager = new ExtenderManager();
 
         $composer = $event->getComposer();

--- a/src/Extender.php
+++ b/src/Extender.php
@@ -67,7 +67,7 @@ class Extender implements PluginInterface, EventSubscriberInterface
         foreach ($localRepository->getPackages() as $package) {
           if ($installationManager->isPackageInstalled($localRepository, $package)) {
             if ($package->getType() === 'drupal-console-library') {
-              $extenderManager->addConfigFile($installationManager->getInstallPath($package) . '/console.services.yml');
+              $extenderManager->addServicesFile($installationManager->getInstallPath($package) . '/console.services.yml');
               $extenderManager->addConfigFile($installationManager->getInstallPath($package) . '/console.config.yml');
             }
           }

--- a/src/Extender.php
+++ b/src/Extender.php
@@ -10,6 +10,11 @@ use Composer\Installer\PackageEvents;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Yaml\Yaml;
 
+// Explicitly require ExtenderManager here.
+// When this package is uninstalled, ExtenderManager needs to be available any
+// time this class is available.
+require_once 'ExtenderManager.php';
+
 class Extender implements PluginInterface, EventSubscriberInterface
 {
     /**
@@ -52,9 +57,6 @@ class Extender implements PluginInterface, EventSubscriberInterface
      */
     public function processPackages(PackageEvent $event)
     {
-        // Explicit require, because during uninstallation, this class can't be
-        // autoloaded.
-        require_once './ExtenderManager.php';
         $extenderManager = new ExtenderManager();
 
         $composer = $event->getComposer();


### PR DESCRIPTION
Hey!
This is a proposal to switch away from using explicit paths to using Composer's APIs to find console extensions.  I'm fairly sure this PR is half baked and broken at the moment, because I don't fully understand the functionality this package provides, but I wanted to throw it out there and see if there's interest in doing it this way.  If there is, I can do some testing to make sure it works as expected. 

This is a followup to #2. 