### PR TITLE
Only look for plugins within the actual package being installed

### DIFF
--- a/src/Extender.php
+++ b/src/Extender.php
@@ -52,62 +52,69 @@ class Extender implements PluginInterface, EventSubscriberInterface
      */
     public function processPackages(PackageEvent $event)
     {
-        $extenderManager = new ExtenderManager();
-        $directory = realpath(__DIR__.'/../../../../');
-        $extenderManager->processProjectPackages($directory);
+      $package = $event->getOperation()->getPackage();
+      $installationManager = $event->getComposer()->getInstallationManager();
+      $projectDirectory = $installationManager->getInstallPath($package);
 
-        if (is_dir($directory.'/vendor/drupal/console')) {
-            $directory = $directory.'/vendor/drupal/console';
-        } else {
-            $configFile = $directory.'/console.config.yml';
-            $servicesFile = $directory.'/console.services.yml';
+        if (is_dir($projectDirectory)) {
+          $extenderManager = new ExtenderManager();
+          $directory = realpath(__DIR__.'/../../../../');
+          $extenderManager->processProjectPackages($projectDirectory);
+
+          if (is_dir($directory . '/vendor/drupal/console')) {
+            $directory = $directory . '/vendor/drupal/console';
+          }
+          else {
+            $configFile = $directory . '/console.config.yml';
+            $servicesFile = $directory . '/console.services.yml';
             $extenderManager->addConfigFile($configFile);
             $extenderManager->addServicesFile($servicesFile);
-        }
+          }
 
-        $configFile = $directory . '/extend.console.config.yml';
-        $servicesFile = $directory . '/extend.console.services.yml';
-        $servicesUninstallFile = $directory . '/extend.console.uninstall.services.yml';
+          $configFile = $directory . '/extend.console.config.yml';
+          $servicesFile = $directory . '/extend.console.services.yml';
+          $servicesUninstallFile = $directory . '/extend.console.uninstall.services.yml';
 
-        if (file_exists($configFile)) {
+          if (file_exists($configFile)) {
             unlink($configFile);
             $this->io->write('<info>Removing config cache file:</info>' . $configFile);
-        }
+          }
 
-        if (file_exists($servicesFile)) {
+          if (file_exists($servicesFile)) {
             unlink($servicesFile);
             $this->io->write('<info>Removing services cache file:</info>' . $servicesFile);
-        }
+          }
 
-        if (file_exists($servicesUninstallFile)) {
+          if (file_exists($servicesUninstallFile)) {
             unlink($servicesUninstallFile);
             $this->io->write('<info>Removing services cache file:</info>' . $servicesUninstallFile);
-        }
+          }
 
-        if ($configData = $extenderManager->getConfigData()) {
+          if ($configData = $extenderManager->getConfigData()) {
             file_put_contents(
-                $configFile,
-                Yaml::dump($configData, 6, 2)
+              $configFile,
+              Yaml::dump($configData, 6, 2)
             );
             $this->io->write('<info>Creating config cache file:</info>' . $configFile);
-        }
+          }
 
-        $servicesData = $extenderManager->getServicesData();
-        if ($servicesData && array_key_exists('install', $servicesData)) {
+          $servicesData = $extenderManager->getServicesData();
+          if ($servicesData && array_key_exists('install', $servicesData)) {
             file_put_contents(
-                $servicesFile,
-                Yaml::dump($servicesData['install'], 4, 2)
+              $servicesFile,
+              Yaml::dump($servicesData['install'], 4, 2)
             );
             $this->io->write('<info>Creating services cache file: </info>' . $servicesFile);
-        }
+          }
 
-        $servicesData = $extenderManager->getServicesData();
-        if ($servicesData && array_key_exists('uninstall', $servicesData)) {
+          $servicesData = $extenderManager->getServicesData();
+          if ($servicesData && array_key_exists('uninstall', $servicesData)) {
             file_put_contents(
-                $servicesUninstallFile,
-                Yaml::dump($servicesData['uninstall'], 4, 2)
+              $servicesUninstallFile,
+              Yaml::dump($servicesData['uninstall'], 4, 2)
             );
             $this->io->write('<info>Creating services cache file: </info>' . $servicesUninstallFile);
+          }
         }
     }
 }


### PR DESCRIPTION
This is fixing Issue #6.  The important stuff is at the beginning, the rest is just white-space issues because of the indention of the block.

Sorry for the formatting but my IDE is set up for Drupal coding standards, so it didn't match the extra spaces and stuff here.

This patch *hugely* improved performance on my site with node_modules and bower_components within my project theme.

However, I'm not sure if this function is doing what was originally intended.  Now it is just looking for Console plugins within the package being installed.  If somehow this was still supposed to search in the entire project folder then the whole logic of this module needs to be revisited, because searching the entire docroot for *every* package install/update is a project breaker here.  So hopefully I got the intent correct.