### PR TITLE
Add Composer 2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "class": "Drupal\\Console\\Composer\\Plugin\\Extender"
     },
     "require": {
-        "composer-plugin-api": "^1.0",
+        "composer-plugin-api": "^1.0 || ^2.0",
         "composer/installers": "^1.2",
         "symfony/yaml": "~3.0|^4.4",
         "symfony/finder": "~3.0|^4.4"

--- a/src/Extender.php
+++ b/src/Extender.php
@@ -160,4 +160,20 @@ class Extender implements PluginInterface, EventSubscriberInterface
             $this->io->write('<info>Cache file can not be deleted</info>');
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        // Nothing to deactivate.
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        // Nothing to uninstall.
+    }	
 }


### PR DESCRIPTION
Composer 2's PluginInterface has added two new methods. Adding stubs for these allows us to be compatible with composer-plugin-api ^2.0.