### PR TITLE
Issue #3337542: Drupal 10 compatibility fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,19 @@
         "class": "Drupal\\Console\\Composer\\Plugin\\Extender"
     },
     "require": {
-        "composer-plugin-api": "^1.0 || ^2.0",
+        "composer-plugin-api": "^1.1 || ^2.0",
         "composer/installers": "^1.2",
-        "symfony/yaml": "~3.0|^4.4",
-        "symfony/finder": "~3.0|^4.4"
+        "symfony/yaml": "^5.4|^6.0",
+        "symfony/finder": "^5.4|^6.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {
         "psr-4": {"Drupal\\Console\\Composer\\Plugin\\": "src"}
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }


### PR DESCRIPTION
The current module version isn't able to use on Drupal 10 implementations.

Some Drupal community members opened the https://www.drupal.org/project/console/issues/3337542 issue, reporting this compatibility issue and brought some fixes. These code modifications were brought by these members.

Please, update this module to cover the new Drupal's version.